### PR TITLE
Allow shepherd_users access to AWS SSM

### DIFF
--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -197,6 +197,31 @@ data "aws_iam_policy_document" "shepherd_users" {
   statement {
     effect = "Allow"
     actions = [
+      "sms:DescribeParameters",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sms:GetParameter*",
+      "sms:PutParameter",
+    ]
+    resources = [
+      format("arn:%s:ssm:%s:%s:parameter/%s-%s/*",
+        data.aws_partition.current.partition,
+        data.aws_region.current.name,
+        data.aws_caller_identity.current.account_id,
+        var.project,
+        var.environment,
+      )
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "tag:*",
     ]
     resources = [

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -197,7 +197,7 @@ data "aws_iam_policy_document" "shepherd_users" {
   statement {
     effect = "Allow"
     actions = [
-      "sms:DescribeParameters",
+      "ssm:DescribeParameters",
     ]
     resources = ["*"]
   }
@@ -205,8 +205,8 @@ data "aws_iam_policy_document" "shepherd_users" {
   statement {
     effect = "Allow"
     actions = [
-      "sms:GetParameter*",
-      "sms:PutParameter",
+      "ssm:GetParameter*",
+      "ssm:PutParameter",
     ]
     resources = [
       format("arn:%s:ssm:%s:%s:parameter/%s-%s/*",
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "shepherd_users" {
         data.aws_caller_identity.current.account_id,
         var.project,
         var.environment,
-      )
+      ),
     ]
   }
 


### PR DESCRIPTION
Reading params from AWS SSM is not yet allowed, making it impossible to update or read values there for the team. This should fix the issue. Test with:

```sh
aws-vault exec dds-shepherd-govcloud -- chamber list shepherd-global
aws-vault exec dds-shepherd-govcloud -- chamber read shepherd-global salt
```