### PR TITLE
Fix error in loadpartitions python script around getting None values

### DIFF
--- a/scripts/loadpartition.py
+++ b/scripts/loadpartition.py
@@ -131,7 +131,9 @@ def s3ListRootObject(s3):
     result = s3.list_objects_v2(
         Bucket=params["s3Bucket"], Delimiter="/", RequestPayer="requester"
     )
-    resultList.extend(result.get("CommonPrefixes"))
+    commonPrefixes = result.get("CommonPrefixes")
+    if commonPrefixes is not None:
+        resultList.extend(commonPrefixes)
     while result["IsTruncated"]:
         result = s3.list_objects_v2(
             Bucket=params["s3Bucket"],
@@ -139,7 +141,9 @@ def s3ListRootObject(s3):
             Delimiter="/",
             ContinuationToken=result["NextContinuationToken"],
         )
-        resultList.extend(result.get("CommonPrefixes"))
+        commonPrefixes = result.get("CommonPrefixes")
+        if commonPrefixes is not None:
+            resultList.extend(commonPrefixes)
     return resultList
 
 


### PR DESCRIPTION
I kept seeing this error:

```
Traceback (most recent call last):
  File "/tmp/loadpartition.py", line 198, in <module>
    subscriberFolders = s3ListRootObject(s3Client)
  File "/tmp/loadpartition.py", line 134, in s3ListRootObject
    resultList.extend(result.get("CommonPrefixes"))
TypeError: 'NoneType' object is not iterable
```

The issue appeared to be that `CommonPrefixes` was not set in the result. I did a safety check on it in this change and tested in athena. It appears to have worked.