### PR TITLE
Allow tagging athena resources

### DIFF
--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -88,6 +88,7 @@ data "aws_iam_policy_document" "shepherd_users_athena" {
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
       "athena:TagResource",
+      "athena:UpdateWorkGroup",
     ]
     effect    = "Allow"
     resources = aws_athena_workgroup.shepherd[*].arn

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -87,6 +87,7 @@ data "aws_iam_policy_document" "shepherd_users_athena" {
       "athena:List*",
       "athena:StartQueryExecution",
       "athena:StopQueryExecution",
+      "athena:TagResource",
     ]
     effect    = "Allow"
     resources = aws_athena_workgroup.shepherd[*].arn


### PR DESCRIPTION
This ought to solve this error:

```
User: arn:aws-us-gov:sts::130252414347:assumed-role/shepherd_users/eli@dds.mil is not authorized to perform: athena:TagResource on resource: arn:aws-us-gov:athena:us-gov-west-1:130252414347:workgroup/shepherd-global-workgroup-sub.dib.caci-oecyehw8 (Service: AmazonAthena; Status Code: 400; Error Code: AccessDeniedException; Request ID: 3b4f32fd-403c-47e4-9705-1063d78dd30a; Proxy: null)
```

The goal is to allow `shepherd_users` to update the workgroup to set `Requestor Pays` attribute.