### PR TITLE
Engineer role and expanded glue permissions for Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ No requirements.
 | environment | n/a | `string` | `"global"` | no |
 | project | n/a | `string` | `"shepherd"` | no |
 | region | n/a | `string` | `"us-gov-west-1"` | no |
+| shepherd\_engineers | The set of IAM user names to add to the 'shepherd\_engineers' group | `list(string)` | `[]` | no |
 | shepherd\_users | The set of IAM user names to add to the 'shepherd\_users' group | `list(string)` | `[]` | no |
 | subscriber\_buckets | The set of AWS S3 buckets to subscribe too | `list(string)` | `[]` | no |
 | tags | The tags for the project | `map(string)` | `{}` | no |

--- a/iam_groups.tf
+++ b/iam_groups.tf
@@ -16,3 +16,22 @@ resource "aws_iam_group_membership" "shepherd_users" {
   group = aws_iam_group.shepherd_users.name
   users = data.aws_iam_user.shepherd_users[*].user_name
 }
+
+
+resource "aws_iam_group" "shepherd_engineers" {
+  name = "shepherd_engineers"
+}
+
+// Using a data resource validates that the engineers exist before applying
+data "aws_iam_user" "shepherd_engineers" {
+  count     = length(var.shepherd_engineers)
+  user_name = var.shepherd_engineers[count.index]
+}
+
+resource "aws_iam_group_membership" "shepherd_engineers" {
+  count = length(var.shepherd_engineers) > 0 ? 1 : 0
+
+  name  = "shepherd_user_group_membership"
+  group = aws_iam_group.shepherd_engineers.name
+  users = data.aws_iam_user.shepherd_engineers[*].user_name
+}

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -143,13 +143,21 @@ data "aws_iam_policy_document" "shepherd_users_glue" {
     effect = "Allow"
     actions = [
       "glue:BatchCreatePartition",
+      "glue:BatchDeletePartition",
+      "glue:BatchDeleteTable",
+      "glue:BatchDeleteTableVersion",
       "glue:CreateTable",
+      "glue:DeleteTable",
+      "glue:DeleteTableVersion",
       "glue:GetDatabase",
       "glue:GetDatabases",
       "glue:GetPartition",
       "glue:GetPartitions",
       "glue:GetTable",
       "glue:GetTables",
+      "glue:GetTableVersion",
+      "glue:UpdatePartition",
+      "glue:UpdateTable",
     ]
     resources = flatten([
       [format("arn:%s:glue:%s:%s:catalog",

--- a/iam_roles.tf
+++ b/iam_roles.tf
@@ -4,3 +4,9 @@ resource "aws_iam_role" "shepherd_users" {
   description        = "Role for 'shepherd_users' to use"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
+
+resource "aws_iam_role" "shepherd_engineers" {
+  name               = "shepherd_engineers"
+  description        = "Role for 'shepherd_engineers' to use"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "shepherd_users" {
   description = "The set of IAM user names to add to the 'shepherd_users' group"
 }
 
+variable "shepherd_engineers" {
+  type        = list(string)
+  default     = []
+  description = "The set of IAM user names to add to the 'shepherd_engineers' group"
+}
+
 variable "subscriber_buckets" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
Two changes:

- A new `shepherd_engineers` role with `*` access to shepherd resources
- Expanded AWS Glue IAM actions for `shepherd_users`.