### PR TITLE
Refactoring for GovCloud

### DIFF
--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -346,20 +346,21 @@ data "aws_iam_policy_document" "shepherd_engineers" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:*",
+      "acm:*",
       "athena:*",
+      "ec2:*",
       "glue:*",
       "iam:Get*",
       "iam:List*",
-      "acm:*",
       "kms:ListAliases",
       "kms:Decrypt",
       "quicksight:*",
+      "rds:*",
       "redshift:*",
       "ssm:*",
+      "s3:*",
       "tag:*",
       "vpc:*",
-      "ec2:*",
     ]
     resources = ["*"]
     condition {

--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -295,7 +295,7 @@ resource "aws_iam_role_policy_attachment" "shepherd_redshift" {
   // https://stackoverflow.com/questions/45486041/how-to-attach-multiple-iam-policies-to-iam-roles-using-terraform
   for_each = toset([
     "arn:aws-us-gov:iam::aws:policy/AmazonRedshiftDataFullAccess",
-    "arn:aws-us-gov:iam::aws:policy/AmazonRedshiftReadOnlyAccess"
+    "arn:aws-us-gov:iam::aws:policy/AmazonRedshiftFullAccess"
   ])
   role       = aws_iam_role.shepherd_users.name
   policy_arn = each.value
@@ -359,6 +359,7 @@ data "aws_iam_policy_document" "shepherd_engineers" {
       "ssm:*",
       "tag:*",
       "vpc:*",
+      "ec2:*",
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
Summary of Changes:

* Added `ec2:*` to `shepherd_engineers` to account for RedShift implementation.
* Modified RedShift permissions due to GovCloud not implementing `AmazonRedshiftReadOnlyAccess`
