### PR TITLE
Proxy data table management updates

### DIFF
--- a/glue_job_loadpartition.tf
+++ b/glue_job_loadpartition.tf
@@ -91,7 +91,7 @@ resource "aws_glue_job" "shepherd_proxy" {
 
   glue_version = "2.0"
 
-  command {         
+  command {
     name            = "pythonshell"
     python_version  = "3"
     script_location = format("s3://%s/%s", module.glue_tmp_bucket.id, aws_s3_bucket_object.loadpartition.key)

--- a/glue_job_loadpartition.tf
+++ b/glue_job_loadpartition.tf
@@ -134,7 +134,7 @@ resource "aws_glue_job" "shepherd_proxy" {
   security_configuration = aws_glue_security_configuration.event_data.id
 
   timeout      = 10     // minutes
-  max_capacity = 0.0625  // Update to 1.0 if needed.
+  max_capacity = 0.0625 // Update to 1.0 if needed.
 
   tags = local.project_tags
 }

--- a/glue_job_loadpartition.tf
+++ b/glue_job_loadpartition.tf
@@ -81,3 +81,74 @@ resource "aws_glue_trigger" "start_workflow_loadpartitions" {
 
   tags = local.project_tags
 }
+
+resource "aws_glue_job" "shepherd_proxy" {
+  count = length(var.subscriber_buckets)
+
+  name        = format("%s-%s-%s-proxy", var.project, var.environment, var.subscriber_buckets[count.index])
+  description = format("The %s %s job to update shepherd data for %s for proxy data", var.project, var.environment, var.subscriber_buckets[count.index])
+  role_arn    = aws_iam_role.glue_role.arn
+
+  glue_version = "2.0"
+
+  command {         
+    name            = "pythonshell"
+    python_version  = "3"
+    script_location = format("s3://%s/%s", module.glue_tmp_bucket.id, aws_s3_bucket_object.loadpartition.key)
+  }
+
+  // See https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html
+  default_arguments = {
+    // Buckets prefixed with 'aws-glue' can be created using the AWS Glue IAM role but we are not using it here
+    "--TempDir" = format("s3://%s/aws-glue/temp/",
+      module.glue_tmp_bucket.id,
+    )
+    "--job-bookmark-option" = "job-bookmark-disable"
+    "--job-language"        = "python"
+
+    // Logging
+    "--enable-continuous-cloudwatch-log" = true
+    "--enable-continuous-log-filter"     = true
+
+    /*
+    /* Script Inputs below Here
+     */
+    "--region" = data.aws_region.current.name
+    // Athena Results
+    "--athenaResultFolder" = var.subscriber_buckets[count.index]
+    "--athenaResultBucket" = module.athena_results.id
+    "--athenaWorkgroup"    = aws_athena_workgroup.shepherd[count.index].id
+    // Database Details
+    "--database"  = split(":", aws_glue_catalog_database.shepherd[count.index].id)[1]
+    "--tableName" = local.proxy_table_name
+    // Source Data
+    "--s3Bucket" = var.subscriber_buckets[count.index]
+    "--s3Folder" = "/"
+    "--dataType" = "proxy"
+  }
+
+  execution_property {
+    max_concurrent_runs = 1
+  }
+
+  security_configuration = aws_glue_security_configuration.event_data.id
+
+  timeout       = 10     // minutes
+  max_capacity = 0.0625  // Update to 1.0 if needed.
+
+  tags = local.project_tags
+}
+
+resource "aws_glue_trigger" "start_workflow_loadpartitions_proxy" {
+  count = length(var.subscriber_buckets)
+
+  name     = format("%s %s schedule triggers etl job to load partitions for %s to proxy table", var.project, var.environment, var.subscriber_buckets[count.index])
+  type     = "SCHEDULED"
+  schedule = "cron(2 0/1 * * ? *)"
+
+  actions {
+    job_name = aws_glue_job.shepherd_proxy[count.index].name
+  }
+
+  tags = local.project_tags
+}

--- a/glue_job_loadpartition.tf
+++ b/glue_job_loadpartition.tf
@@ -133,7 +133,7 @@ resource "aws_glue_job" "shepherd_proxy" {
 
   security_configuration = aws_glue_security_configuration.event_data.id
 
-  timeout       = 10     // minutes
+  timeout      = 10     // minutes
   max_capacity = 0.0625  // Update to 1.0 if needed.
 
   tags = local.project_tags


### PR DESCRIPTION
**PR should not be approved prior to DDS-Akamai meeting tentatively scheduled for Monday, 7 June.**

Updates to enable the creation and regular updating of proxy data table. Changes include:

- athena.tf - Added template_file.create_proxy_table resource to generate create table DDL statement using create_proxy_table_spec.sql.tmpl (see PR #32).
- athena.tf - Added proxy_table_name ("proxy_data") to locals stanza.
- glue_job_loadpartition.tf - Added aws_glue_job.shepherd_proxy resource to call loadpartition.py Glue job for proxy table. Generally similar to existing aws_glue_job.shepherd stanza, but 1) uses param --dataType=proxy instead of --dataType=dns, 2) uses param --tableName=local.proxy_table_name instead of  --tableName=local.table_name, and 3) runs in a pythonshell execution environment instead of glueetl. Previous updates to loadpartition.py script (see PR #32) permit using the same script for both DNS and proxy table partition management.
- glue_job_loadpartition.tf - Added aws_glue_trigger.start_workflow_loadpartitions_proxy resource to schedule aws_glue_job.shepherd_proxy Glue job. Generally similar to existing aws_glue_trigger.start_workflow_loadpartitions resource, except 1) targets the job_name aws_glue_job.shepherd_proxy[count.index].name instead of aws_glue_job.shepherd[count.index].name, and 2) executes at two minutes past the hour instead of one minute past the hour as in the case of aws_glue_trigger.start_workflow_loadpartitions.
