### PR TITLE
Enabling logging access for shepherd_engineers

### DIFF
--- a/iam_policies.tf
+++ b/iam_policies.tf
@@ -365,6 +365,7 @@ data "aws_iam_policy_document" "shepherd_engineers" {
       "iam:List*",
       "kms:ListAliases",
       "kms:Decrypt",
+      "logs:*",
       "quicksight:*",
       "rds:*",
       "redshift:*",


### PR DESCRIPTION
### Summary of Changes

* Allowed the `shepherd_engineers` group to have access to view logs within AWS. 